### PR TITLE
Fixed client to server communication

### DIFF
--- a/app/Graphrec/app/build.gradle
+++ b/app/Graphrec/app/build.gradle
@@ -26,5 +26,6 @@ dependencies {
     })
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'com.squareup.okhttp3:okhttp:3.7.0'
     testCompile 'junit:junit:4.12'
 }

--- a/app/Graphrec/app/src/main/java/com/app/graphrec/graphrec/CameraActivity.java
+++ b/app/Graphrec/app/src/main/java/com/app/graphrec/graphrec/CameraActivity.java
@@ -73,7 +73,7 @@ public class CameraActivity extends Activity {
 
         // Right now we create a secret temp file to transfer img to main activity
         // can this be done in a better way?
-        File tempFile = new File(getExternalFilesDir(null), "tempImg.jpg");
+        File tempFile = new File(getExternalFilesDir(null), "tempImg.png");
 
         try {
             FileOutputStream output = new FileOutputStream(tempFile.getAbsoluteFile());

--- a/app/Graphrec/app/src/main/java/com/app/graphrec/graphrec/CameraActivity.java
+++ b/app/Graphrec/app/src/main/java/com/app/graphrec/graphrec/CameraActivity.java
@@ -59,8 +59,6 @@ public class CameraActivity extends Activity {
         @Override
         public void onPictureTaken(byte[] data, Camera camera) {
             Intent intent = new Intent();
-            // May be a bad approach since it is possible for it to crash
-            // when transferring large images.
             File image = createImageFile(data);
             intent.putExtra("picture", image.toURI().toString());
             setResult(RESULT_OK, intent);

--- a/app/Graphrec/app/src/main/java/com/app/graphrec/graphrec/MainActivity.java
+++ b/app/Graphrec/app/src/main/java/com/app/graphrec/graphrec/MainActivity.java
@@ -11,9 +11,9 @@ import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+
 import static android.content.ContentValues.TAG;
 
 /**
@@ -39,6 +39,7 @@ public class MainActivity extends AppCompatActivity {
             Bitmap imageBitmap = getBitmapFromUri(imageUri);
             ImageView view = (ImageView) findViewById(R.id.imageView);
             view.setImageBitmap(imageBitmap);
+            sendRequest(imageUri);
         }
     }
 
@@ -50,11 +51,6 @@ public class MainActivity extends AppCompatActivity {
             Log.d(TAG, "Error trying to open temp file " + e.getMessage());
         }
 
-        // cleanup
-        File tempfile = new File(uri.getPath());
-        if (!tempfile.delete()) {
-            Log.d(TAG, "Error trying to delete temp file ");
-        }
         return bitmap;
     }
 
@@ -63,8 +59,8 @@ public class MainActivity extends AppCompatActivity {
         startActivityForResult(intent, CAMERA_ACTIVITY);
     }
 
-    public void sendRequest() {
-        new ImageUploadTask().execute();
+    public void sendRequest(Uri uri) {
+        new ImageUploadTask().execute(uri);
     }
 
 }

--- a/app/Graphrec/app/src/main/java/com/app/graphrec/graphrec/MainActivity.java
+++ b/app/Graphrec/app/src/main/java/com/app/graphrec/graphrec/MainActivity.java
@@ -45,8 +45,7 @@ public class MainActivity extends AppCompatActivity {
     private Bitmap getBitmapFromUri(Uri uri) {
         Bitmap bitmap = null;
         try {
-            FileInputStream stream = new FileInputStream(uri.getPath());
-            bitmap = BitmapFactory.decodeStream(stream);
+            bitmap = BitmapFactory.decodeStream(new FileInputStream(uri.getPath()));
         } catch (FileNotFoundException e) {
             Log.d(TAG, "Error trying to open temp file " + e.getMessage());
         }

--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -25,7 +25,7 @@ def upload_image():
 		f = request.files['file']
 		filename = secure_filename(f.filename)
 		extension = '.' + filename.rsplit('.', 1)[1].lower()
-		if extension not in ALLOWED_EXTENSIONS:
+		if extension[1:] not in ALLOWED_EXTENSIONS:
 			response = "File extension %s not allowed" % extension
 			return response
 		full_path = os.path.join(app.config['UPLOAD_FOLDER'], app.config['IMAGE_NAME'] + extension)


### PR DESCRIPTION
This pull request implements #17, implements #4, implements #7.
There were two ways to send the data with HTTP. The first option was to just send the stream in the body of the HTTP POST request and then rewrite the server to handle that. This way would require extensive validation efforts and would most likely be hard to maintain down the road. 

I chose the second option, which means that we embrace the flask way, i.e. use HTTP forms and multipart requests. This approach would create a bit work on the client side because the HTTPUrlConnection is pretty weak when it comes to multipart requests. I used the [http://square.github.io/okhttp/](OkHTTP library) to aid me in this task.